### PR TITLE
Adding desktop shortcuts for lab instructions and VS Code

### DIFF
--- a/azure_arc_servers_jumpstart/artifacts/ArcServersLogonScript.ps1
+++ b/azure_arc_servers_jumpstart/artifacts/ArcServersLogonScript.ps1
@@ -58,6 +58,25 @@ $Shortcut.TargetPath = $WinTerminalPath
 $shortcut.WindowStyle = 3
 $shortcut.Save()
 
+# Adding desktop shortcut for lab instructions
+$WshShell = New-Object -comObject WScript.Shell
+$Shortcut = $WshShell.CreateShortcut("$Env:USERPROFILE\Desktop\Lab instructions.lnk")
+$Shortcut.TargetPath = "https://aka.ms/arc-follow-along"
+$Shortcut.IconLocation = "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+$shortcut.WindowStyle = 3
+$shortcut.Save()
+
+# Adding desktop shortcut for VS Code
+Copy-Item -Path "$Env:USERPROFILE\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Visual Studio Code\Visual Studio Code.lnk" -Destination "$Env:USERPROFILE\Desktop" -Force
+
+# Cloning the Azure Arc Jumpstart levelup repository
+git clone https://github.com/Azure/arc_jumpstart_levelup.git C:\PSConfEU
+
+Set-Location C:\PSConfEU
+
+git checkout psconfeu
+
+
 # Configure Windows Terminal as the default terminal application
 $registryPath = "HKCU:\Console\%%Startup"
 


### PR DESCRIPTION
This pull request introduces changes to the `azure_arc_servers_jumpstart/artifacts/ArcServersLogonScript.ps1` file. The changes include adding desktop shortcuts for lab instructions and Visual Studio Code, and cloning the Azure Arc Jumpstart levelup repository.

* [`azure_arc_servers_jumpstart/artifacts/ArcServersLogonScript.ps1`](diffhunk://#diff-2d982074f8fa7cdee9cec85e552097a1fb9ccac602efd8235c3fb8a55caa8076R61-R79): Added code to create a desktop shortcut for lab instructions, specifying the target path, icon location, and window style. Also, added a desktop shortcut for Visual Studio Code and cloned the Azure Arc Jumpstart levelup repository.