### PR TITLE
Update SSH configuration for PowerShell subsystem: Remove typo

### DIFF
--- a/docs/azure_arc_servers_jumpstart/_readme.md
+++ b/docs/azure_arc_servers_jumpstart/_readme.md
@@ -804,7 +804,6 @@ For this task, we will be using the *ArcBox-Ubuntu-01* machine as the target.
 
 A prerequisite is to enable the PowerShell subsystem in the sshd configuration:
 
-Log on to the
 ```powershell
 $serverName = "ArcBox-Ubuntu-01"
 az ssh arc --resource-group $Env:resourceGroup --name $serverName


### PR DESCRIPTION
This pull request includes a minor change to the `docs/azure_arc_servers_jumpstart/_readme.md` file. The change removes the phrase "Log on to the" which appears to be incomplete or unnecessary in the context of the instructions provided. This makes the document clearer and more concise.