### PR TITLE
storage account need public blob for config management

### DIFF
--- a/azure_arc_servers_jumpstart/ARM/azuredeploy.json
+++ b/azure_arc_servers_jumpstart/ARM/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.34.44.8038",
-      "templateHash": "2223284559391923513"
+      "templateHash": "11173761397765479396"
     }
   },
   "parameters": {
@@ -486,7 +486,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.34.44.8038",
-              "templateHash": "4289366467962618221"
+              "templateHash": "8218817562109447016"
             }
           },
           "parameters": {
@@ -525,7 +525,8 @@
               },
               "kind": "StorageV2",
               "properties": {
-                "supportsHttpsTrafficOnly": true
+                "supportsHttpsTrafficOnly": true,
+                "allowBlobPublicAccess": true
               }
             }
           ],

--- a/azure_arc_servers_jumpstart/bicep/mgmt/mgmtStagingStorage.bicep
+++ b/azure_arc_servers_jumpstart/bicep/mgmt/mgmtStagingStorage.bicep
@@ -21,6 +21,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   kind: 'StorageV2'
   properties: {
     supportsHttpsTrafficOnly: true
+    allowBlobPublicAccess: true
   }
 }
 


### PR DESCRIPTION
Need to make the storage account accessible so that we use it in Machine Config rather than creating another account (which is causing a number of problems in the workshops when users create more than one by mistake)